### PR TITLE
Add student CRUD Flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+students.db
+__pycache__/
+*.pyc
+server.log
+instance/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# Chatgpt-Project
-Chatgpt Project
+# Student CRUD Web App
+
+This project provides a simple Flask-based web interface to create, read, update, and delete students.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+   The app will start at http://127.0.0.1:5000.
+
+## Testing
+
+Run the automated tests with:
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,113 @@
+
+from datetime import datetime
+from flask import Flask, render_template, request, redirect, url_for, flash
+from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import FlaskForm
+from wtforms import StringField, DateField, SubmitField
+from wtforms.validators import DataRequired, Email, Optional, Length
+import os
+
+app = Flask(__name__)
+app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "change-me-in-production")
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///students.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+db = SQLAlchemy(app)
+
+class Student(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(80), nullable=False, index=True)
+    last_name = db.Column(db.String(80), nullable=False, index=True)
+    email = db.Column(db.String(120), unique=True, nullable=False, index=True)
+    phone = db.Column(db.String(30))
+    birthdate = db.Column(db.Date)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+class StudentForm(FlaskForm):
+    first_name = StringField("First name", validators=[DataRequired(), Length(max=80)])
+    last_name = StringField("Last name", validators=[DataRequired(), Length(max=80)])
+    email = StringField("Email", validators=[DataRequired(), Email(), Length(max=120)])
+    phone = StringField("Phone", validators=[Optional(), Length(max=30)])
+    birthdate = DateField("Birthdate (YYYY-MM-DD)", validators=[Optional()], format="%Y-%m-%d")
+    submit = SubmitField("Save")
+
+@app.route("/", methods=["GET"])
+def index():
+    q = request.args.get("q", "").strip()
+    page = request.args.get("page", 1, type=int)
+    query = Student.query
+    if q:
+        like = f"%{q}%"
+        query = query.filter(
+            db.or_(
+                Student.first_name.ilike(like),
+                Student.last_name.ilike(like),
+                Student.email.ilike(like),
+                Student.phone.ilike(like),
+            )
+        )
+    students = query.order_by(Student.created_at.desc()).paginate(page=page, per_page=10)
+    return render_template("index.html", students=students, q=q)
+
+@app.route("/students/new", methods=["GET", "POST"])
+def create_student():
+    form = StudentForm()
+    if form.validate_on_submit():
+        s = Student(
+            first_name=form.first_name.data,
+            last_name=form.last_name.data,
+            email=form.email.data,
+            phone=form.phone.data or None,
+            birthdate=form.birthdate.data or None,
+        )
+        db.session.add(s)
+        try:
+            db.session.commit()
+            flash("Student created successfully.", "success")
+            return redirect(url_for("index"))
+        except Exception:
+            db.session.rollback()
+            flash("Email must be unique or data invalid.", "danger")
+    return render_template("form.html", form=form, title="Add student")
+
+@app.route("/students/<int:student_id>", methods=["GET"])
+def show_student(student_id):
+    s = Student.query.get_or_404(student_id)
+    return render_template("show.html", s=s)
+
+@app.route("/students/<int:student_id>/edit", methods=["GET", "POST"])
+def edit_student(student_id):
+    s = Student.query.get_or_404(student_id)
+    form = StudentForm(obj=s)
+    if form.validate_on_submit():
+        s.first_name = form.first_name.data
+        s.last_name = form.last_name.data
+        s.email = form.email.data
+        s.phone = form.phone.data or None
+        s.birthdate = form.birthdate.data or None
+        try:
+            db.session.commit()
+            flash("Student updated.", "success")
+            return redirect(url_for("show_student", student_id=s.id))
+        except Exception:
+            db.session.rollback()
+            flash("Update failed (email must be unique?).", "danger")
+    return render_template("form.html", form=form, title="Edit student")
+
+@app.route("/students/<int:student_id>/delete", methods=["POST"])
+def delete_student(student_id):
+    s = Student.query.get_or_404(student_id)
+    db.session.delete(s)
+    db.session.commit()
+    flash("Student deleted.", "info")
+    return redirect(url_for("index"))
+
+@app.route("/__health")
+def health():
+    return {"status": "ok", "students": Student.query.count()}
+
+with app.app_context():
+    db.create_all()
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+flask_sqlalchemy
+flask_wtf
+wtforms
+email-validator

--- a/run_windows.bat
+++ b/run_windows.bat
@@ -1,0 +1,11 @@
+
+@echo off
+REM Activate venv, install deps, and run Flask
+if not exist .venv (
+  py -3 -m venv .venv || python -m venv .venv
+)
+call .venv\Scripts\activate.bat
+pip install -r requirements.txt
+set FLASK_APP=app.py
+set FLASK_DEBUG=1
+flask run --host=0.0.0.0 --port=5000

--- a/static/custom.css
+++ b/static/custom.css
@@ -1,0 +1,1 @@
+.table td, .table th { vertical-align: middle; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,31 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Student Manager</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='custom.css') }}" rel="stylesheet">
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container">
+        <a class="navbar-brand" href="{{ url_for('index') }}">Student Manager</a>
+        <a class="btn btn-success ms-auto" href="{{ url_for('create_student') }}">+ Add</a>
+      </div>
+    </nav>
+    <main class="container py-4">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <div class="mb-3">
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }} mb-2">{{ message }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,0 +1,42 @@
+
+{% extends "base.html" %}
+{% block content %}
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h5 class="card-title mb-3">{{ title }}</h5>
+    <form method="post" novalidate>
+      {{ form.hidden_tag() }}
+      <div class="row g-3">
+        <div class="col-md-6">
+          <label class="form-label">First name</label>
+          {{ form.first_name(class="form-control") }}
+          {% for e in form.first_name.errors %}<div class="text-danger small">{{ e }}</div>{% endfor %}
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Last name</label>
+          {{ form.last_name(class="form-control") }}
+          {% for e in form.last_name.errors %}<div class="text-danger small">{{ e }}</div>{% endfor %}
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Email</label>
+          {{ form.email(class="form-control") }}
+          {% for e in form.email.errors %}<div class="text-danger small">{{ e }}</div>{% endfor %}
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Phone</label>
+          {{ form.phone(class="form-control") }}
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Birthdate</label>
+          {{ form.birthdate(class="form-control", placeholder="YYYY-MM-DD") }}
+          {% for e in form.birthdate.errors %}<div class="text-danger small">{{ e }}</div>{% endfor %}
+        </div>
+      </div>
+      <div class="mt-4 d-flex gap-2">
+        {{ form.submit(class="btn btn-primary") }}
+        <a class="btn btn-outline-secondary" href="{{ url_for('index') }}">Cancel</a>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,61 @@
+
+{% extends "base.html" %}
+{% block content %}
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h5 class="mb-3">Students</h5>
+    <form class="row g-2 mb-3" method="get">
+      <div class="col-md-10">
+        <input type="text" class="form-control" name="q" placeholder="Search by name, email or phone" value="{{ q }}">
+      </div>
+      <div class="col-md-2 d-grid">
+        <button class="btn btn-primary" type="submit">Search</button>
+      </div>
+    </form>
+
+    <div class="table-responsive">
+      <table class="table table-hover align-middle">
+        <thead>
+          <tr>
+            <th>#</th><th>First</th><th>Last</th><th>Email</th><th>Phone</th><th>Created</th><th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for s in students.items %}
+          <tr>
+            <td>{{ s.id }}</td>
+            <td>{{ s.first_name }}</td>
+            <td>{{ s.last_name }}</td>
+            <td><a href="{{ url_for('show_student', student_id=s.id) }}">{{ s.email }}</a></td>
+            <td>{{ s.phone or '' }}</td>
+            <td>{{ s.created_at.strftime('%Y-%m-%d') }}</td>
+            <td class="text-end">
+              <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('edit_student', student_id=s.id) }}">Edit</a>
+              <form class="d-inline" method="post" action="{{ url_for('delete_student', student_id=s.id) }}" onsubmit="return confirm('Delete this student?');">
+                <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
+              </form>
+            </td>
+          </tr>
+          {% else %}
+          <tr><td colspan="7" class="text-center text-muted">No students yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <nav>
+      <ul class="pagination">
+        {% if students.has_prev %}
+          <li class="page-item"><a class="page-link" href="?q={{ q }}&page={{ students.prev_num }}">«</a></li>
+        {% else %}<li class="page-item disabled"><span class="page-link">«</span></li>{% endif %}
+
+        <li class="page-item disabled"><span class="page-link">Page {{ students.page }} / {{ students.pages or 1 }}</span></li>
+
+        {% if students.has_next %}
+          <li class="page-item"><a class="page-link" href="?q={{ q }}&page={{ students.next_num }}">»</a></li>
+        {% else %}<li class="page-item disabled"><span class="page-link">»</span></li>{% endif %}
+      </ul>
+    </nav>
+  </div>
+</div>
+{% endblock %}

--- a/templates/show.html
+++ b/templates/show.html
@@ -1,0 +1,17 @@
+
+{% extends "base.html" %}
+{% block content %}
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h5 class="card-title">{{ s.first_name }} {{ s.last_name }}</h5>
+    <dl class="row">
+      <dt class="col-sm-3">Email</dt><dd class="col-sm-9">{{ s.email }}</dd>
+      <dt class="col-sm-3">Phone</dt><dd class="col-sm-9">{{ s.phone or '—' }}</dd>
+      <dt class="col-sm-3">Birthdate</dt><dd class="col-sm-9">{{ s.birthdate or '—' }}</dd>
+      <dt class="col-sm-3">Created</dt><dd class="col-sm-9">{{ s.created_at.strftime('%Y-%m-%d %H:%M') }}</dd>
+    </dl>
+    <a class="btn btn-outline-secondary" href="{{ url_for('edit_student', student_id=s.id) }}">Edit</a>
+    <a class="btn btn-primary" href="{{ url_for('index') }}">Back</a>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,10 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import app
+
+def test_health_endpoint():
+    client = app.app.test_client()
+    resp = client.get("/__health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "ok"


### PR DESCRIPTION
## Summary
- add Flask-based app to create, view, edit, and delete students
- add basic test for health endpoint and ignore generated files
- document setup and usage

## Testing
- `pytest`
- `curl -s http://127.0.0.1:5000/__health`

------
https://chatgpt.com/codex/tasks/task_e_689ca769bd74832b87d78c31e592d000