### PR TITLE
Add international phone input with country selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ class StudentForm(FlaskForm):
     first_name = StringField("First name", validators=[DataRequired(), Length(max=80)])
     last_name = StringField("Last name", validators=[DataRequired(), Length(max=80)])
     email = StringField("Email", validators=[DataRequired(), Email(), Length(max=120)])
-    phone = StringField("Phone", validators=[Optional(), Length(max=30)])
+    phone = StringField("Phone", validators=[Optional(), Length(max=30)], render_kw={"type": "tel"})
     birthdate = DateField("Birthdate (YYYY-MM-DD)", validators=[Optional()], format="%Y-%m-%d")
     submit = SubmitField("Save")
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
     <title>Student Manager</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="{{ url_for('static', filename='custom.css') }}" rel="stylesheet">
+    {% block extra_head %}{% endblock %}
   </head>
   <body class="bg-light">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -27,5 +28,6 @@
       {% endwith %}
       {% block content %}{% endblock %}
     </main>
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,5 +1,10 @@
 
 {% extends "base.html" %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/intl-tel-input@18.2.1/build/css/intlTelInput.css">
+{% endblock %}
+
 {% block content %}
 <div class="card shadow-sm">
   <div class="card-body">
@@ -24,7 +29,7 @@
         </div>
         <div class="col-md-3">
           <label class="form-label">Phone</label>
-          {{ form.phone(class="form-control") }}
+          {{ form.phone(class="form-control", id="phone") }}
         </div>
         <div class="col-md-3">
           <label class="form-label">Birthdate</label>
@@ -39,4 +44,17 @@
     </form>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/intl-tel-input@18.2.1/build/js/intlTelInput.min.js"></script>
+<script>
+  const input = document.querySelector("#phone");
+  const iti = window.intlTelInput(input, {
+    utilsScript: "https://cdn.jsdelivr.net/npm/intl-tel-input@18.2.1/build/js/utils.js"
+  });
+  input.form.addEventListener("submit", function() {
+    input.value = iti.getNumber();
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- enable country-specific phone input with flags and dialing codes
- expose blocks in base template for extra assets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cadf8322c832ba00d899c3f1c3c5b