### PR TITLE
Add speciality and class fields to Student records

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,8 @@ class Student(db.Model):
     last_name = db.Column(db.String(80), nullable=False, index=True)
     email = db.Column(db.String(120), unique=True, nullable=False, index=True)
     phone = db.Column(db.String(30))
+    speciality = db.Column(db.String(80))
+    student_class = db.Column(db.String(30))
     birthdate = db.Column(db.Date)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -28,7 +30,11 @@ class StudentForm(FlaskForm):
     last_name = StringField("Last name", validators=[DataRequired(), Length(max=80)])
     email = StringField("Email", validators=[DataRequired(), Email(), Length(max=120)])
     phone = StringField("Phone", validators=[Optional(), Length(max=30)])
-    birthdate = DateField("Birthdate (YYYY-MM-DD)", validators=[Optional()], format="%Y-%m-%d")
+    speciality = StringField("Speciality", validators=[Optional(), Length(max=80)])
+    student_class = StringField("Class", validators=[Optional(), Length(max=30)])
+    birthdate = DateField(
+        "Birthdate (YYYY-MM-DD)", validators=[Optional()], format="%Y-%m-%d"
+    )
     submit = SubmitField("Save")
 
 @app.route("/", methods=["GET"])
@@ -58,6 +64,8 @@ def create_student():
             last_name=form.last_name.data,
             email=form.email.data,
             phone=form.phone.data or None,
+            speciality=form.speciality.data or None,
+            student_class=form.student_class.data or None,
             birthdate=form.birthdate.data or None,
         )
         db.session.add(s)
@@ -84,6 +92,8 @@ def edit_student(student_id):
         s.last_name = form.last_name.data
         s.email = form.email.data
         s.phone = form.phone.data or None
+        s.speciality = form.speciality.data or None
+        s.student_class = form.student_class.data or None
         s.birthdate = form.birthdate.data or None
         try:
             db.session.commit()

--- a/templates/form.html
+++ b/templates/form.html
@@ -31,6 +31,14 @@
           {{ form.birthdate(class="form-control", placeholder="YYYY-MM-DD") }}
           {% for e in form.birthdate.errors %}<div class="text-danger small">{{ e }}</div>{% endfor %}
         </div>
+        <div class="col-md-6">
+          <label class="form-label">Speciality</label>
+          {{ form.speciality(class="form-control") }}
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Class</label>
+          {{ form.student_class(class="form-control") }}
+        </div>
       </div>
       <div class="mt-4 d-flex gap-2">
         {{ form.submit(class="btn btn-primary") }}

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
       <table class="table table-hover align-middle">
         <thead>
           <tr>
-            <th>#</th><th>First</th><th>Last</th><th>Email</th><th>Phone</th><th>Created</th><th></th>
+            <th>#</th><th>First</th><th>Last</th><th>Email</th><th>Phone</th><th>Speciality</th><th>Class</th><th>Created</th><th></th>
           </tr>
         </thead>
         <tbody>
@@ -28,6 +28,8 @@
             <td>{{ s.last_name }}</td>
             <td><a href="{{ url_for('show_student', student_id=s.id) }}">{{ s.email }}</a></td>
             <td>{{ s.phone or '' }}</td>
+            <td>{{ s.speciality or '' }}</td>
+            <td>{{ s.student_class or '' }}</td>
             <td>{{ s.created_at.strftime('%Y-%m-%d') }}</td>
             <td class="text-end">
               <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('edit_student', student_id=s.id) }}">Edit</a>
@@ -37,7 +39,7 @@
             </td>
           </tr>
           {% else %}
-          <tr><td colspan="7" class="text-center text-muted">No students yet.</td></tr>
+          <tr><td colspan="9" class="text-center text-muted">No students yet.</td></tr>
           {% endfor %}
         </tbody>
       </table>

--- a/templates/show.html
+++ b/templates/show.html
@@ -7,6 +7,8 @@
     <dl class="row">
       <dt class="col-sm-3">Email</dt><dd class="col-sm-9">{{ s.email }}</dd>
       <dt class="col-sm-3">Phone</dt><dd class="col-sm-9">{{ s.phone or '—' }}</dd>
+      <dt class="col-sm-3">Speciality</dt><dd class="col-sm-9">{{ s.speciality or '—' }}</dd>
+      <dt class="col-sm-3">Class</dt><dd class="col-sm-9">{{ s.student_class or '—' }}</dd>
       <dt class="col-sm-3">Birthdate</dt><dd class="col-sm-9">{{ s.birthdate or '—' }}</dd>
       <dt class="col-sm-3">Created</dt><dd class="col-sm-9">{{ s.created_at.strftime('%Y-%m-%d %H:%M') }}</dd>
     </dl>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,9 +2,68 @@ import sys, os
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import app
 
+
+def setup_module(module):
+    """Prepare a fresh database for tests."""
+    app.app.config["WTF_CSRF_ENABLED"] = False
+    with app.app.app_context():
+        app.db.drop_all()
+        app.db.create_all()
+
 def test_health_endpoint():
     client = app.app.test_client()
     resp = client.get("/__health")
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["status"] == "ok"
+
+
+def test_create_edit_student_fields():
+    client = app.app.test_client()
+    # create a student with new fields
+    resp = client.post(
+        "/students/new",
+        data={
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john@example.com",
+            "phone": "",
+            "birthdate": "",
+            "speciality": "Math",
+            "student_class": "1A",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+
+    with app.app.app_context():
+        s = app.Student.query.filter_by(email="john@example.com").first()
+        assert s is not None
+        assert s.speciality == "Math"
+        assert s.student_class == "1A"
+        student_id = s.id
+
+    # edit the student
+    resp = client.post(
+        f"/students/{student_id}/edit",
+        data={
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john@example.com",
+            "phone": "",
+            "birthdate": "",
+            "speciality": "Physics",
+            "student_class": "2B",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+
+    with app.app.app_context():
+        s = app.Student.query.get(student_id)
+        assert s.speciality == "Physics"
+        assert s.student_class == "2B"
+
+    resp = client.get(f"/students/{student_id}")
+    assert b"Physics" in resp.data
+    assert b"2B" in resp.data


### PR DESCRIPTION
## Summary
- add `speciality` and `student_class` columns to `Student` model
- extend forms and templates to capture and display the new fields
- add test covering creation and editing of these attributes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb9304e8c832b8cd5866cc705560d