### PR TITLE
Add leave/recovery management: models, routes, templates, DB schema and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,133 +1,286 @@
+from datetime import date, datetime
+import os
 
-from datetime import datetime
-from flask import Flask, render_template, request, redirect, url_for, flash
+from flask import Flask, flash, redirect, render_template, request, url_for
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import FlaskForm
-from wtforms import StringField, DateField, SubmitField
-from wtforms.validators import DataRequired, Email, Optional, Length
-from sqlalchemy import inspect, text
-import os
+from sqlalchemy import CheckConstraint, UniqueConstraint
+from wtforms import DateField, FloatField, SelectField, StringField, SubmitField, TextAreaField
+from wtforms.validators import DataRequired, NumberRange, Optional
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "change-me-in-production")
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///students.db"
+app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("DATABASE_URL", "sqlite:///leave_app.db")
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 db = SQLAlchemy(app)
 
-class Student(db.Model):
+
+class Team(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    first_name = db.Column(db.String(80), nullable=False, index=True)
-    last_name = db.Column(db.String(80), nullable=False, index=True)
-    email = db.Column(db.String(120), unique=True, nullable=False, index=True)
-    phone = db.Column(db.String(30))
-    speciality = db.Column(db.String(80))
-    student_class = db.Column(db.String(30))
-    birthdate = db.Column(db.Date)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    name = db.Column(db.String(120), unique=True, nullable=False)
 
-class StudentForm(FlaskForm):
-    first_name = StringField("First name", validators=[DataRequired(), Length(max=80)])
-    last_name = StringField("Last name", validators=[DataRequired(), Length(max=80)])
-    email = StringField("Email", validators=[DataRequired(), Email(), Length(max=120)])
-    phone = StringField("Phone", validators=[Optional(), Length(max=30)])
-    speciality = StringField("Speciality", validators=[Optional(), Length(max=80)])
-    student_class = StringField("Class", validators=[Optional(), Length(max=30)])
-    birthdate = DateField(
-        "Birthdate (YYYY-MM-DD)", validators=[Optional()], format="%Y-%m-%d"
+
+class Employee(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(120), nullable=False)
+    last_name = db.Column(db.String(120), nullable=False)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    role = db.Column(db.String(40), nullable=False, default="EMPLOYEE")
+    leave_balance = db.Column(db.Float, nullable=False, default=0)
+    leave_reserved = db.Column(db.Float, nullable=False, default=0)
+    recovery_balance = db.Column(db.Float, nullable=False, default=0)
+    recovery_reserved = db.Column(db.Float, nullable=False, default=0)
+
+    team_id = db.Column(db.Integer, db.ForeignKey("team.id"))
+    functional_manager_id = db.Column(db.Integer, db.ForeignKey("employee.id"))
+    hierarchical_manager_id = db.Column(db.Integer, db.ForeignKey("employee.id"))
+
+    team = db.relationship("Team", backref="employees")
+
+    __table_args__ = (
+        CheckConstraint("leave_balance >= 0"),
+        CheckConstraint("leave_reserved >= 0"),
+        CheckConstraint("recovery_balance >= 0"),
+        CheckConstraint("recovery_reserved >= 0"),
     )
-    submit = SubmitField("Save")
 
-@app.route("/", methods=["GET"])
+    @property
+    def full_name(self):
+        return f"{self.first_name} {self.last_name}"
+
+
+class LeaveRequest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    employee_id = db.Column(db.Integer, db.ForeignKey("employee.id"), nullable=False)
+    request_type = db.Column(db.String(20), nullable=False)  # LEAVE / RECOVERY / AUTH
+    start_date = db.Column(db.Date, nullable=False)
+    end_date = db.Column(db.Date, nullable=False)
+    quantity = db.Column(db.Float, nullable=False)
+    reason = db.Column(db.Text)
+    status = db.Column(db.String(30), nullable=False, default="PENDING_FUNCTIONAL")
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now())
+
+    functional_decision = db.Column(db.String(20), default="PENDING")
+    hierarchical_decision = db.Column(db.String(20), default="PENDING")
+    hr_decision = db.Column(db.String(20), default="PENDING")
+
+    employee = db.relationship("Employee", backref="requests")
+
+    __table_args__ = (
+        CheckConstraint("quantity > 0"),
+        CheckConstraint("start_date <= end_date"),
+    )
+
+
+class EmployeeForm(FlaskForm):
+    first_name = StringField("Prénom", validators=[DataRequired()])
+    last_name = StringField("Nom", validators=[DataRequired()])
+    email = StringField("Email", validators=[DataRequired()])
+    role = SelectField(
+        "Rôle",
+        choices=[
+            ("EMPLOYEE", "Employé"),
+            ("MANAGER_FUNCTIONAL", "Manager fonctionnel"),
+            ("MANAGER_HIERARCHICAL", "Manager hiérarchique"),
+            ("HR", "RH"),
+        ],
+        validators=[DataRequired()],
+    )
+    team_id = SelectField("Équipe", coerce=int, validators=[Optional()])
+    functional_manager_id = SelectField("Manager fonctionnel", coerce=int, validators=[Optional()])
+    hierarchical_manager_id = SelectField("Manager hiérarchique", coerce=int, validators=[Optional()])
+    leave_balance = FloatField("Solde congé", validators=[DataRequired(), NumberRange(min=0)])
+    recovery_balance = FloatField("Solde récupération", validators=[DataRequired(), NumberRange(min=0)])
+    submit = SubmitField("Enregistrer")
+
+
+class LeaveRequestForm(FlaskForm):
+    employee_id = SelectField("Employé", coerce=int, validators=[DataRequired()])
+    request_type = SelectField(
+        "Type",
+        choices=[("LEAVE", "Congé"), ("RECOVERY", "Récupération"), ("AUTH", "Autorisation")],
+        validators=[DataRequired()],
+    )
+    start_date = DateField("Date début", validators=[DataRequired()], format="%Y-%m-%d")
+    end_date = DateField("Date fin", validators=[DataRequired()], format="%Y-%m-%d")
+    quantity = FloatField("Quantité (jours/heures)", validators=[DataRequired(), NumberRange(min=0.5)])
+    reason = TextAreaField("Motif", validators=[Optional()])
+    submit = SubmitField("Soumettre")
+
+
+def _seed_if_empty():
+    if Employee.query.count() > 0:
+        return
+    t1 = Team(name="IT")
+    t2 = Team(name="RH")
+    db.session.add_all([t1, t2])
+    db.session.flush()
+
+    hr = Employee(first_name="Sami", last_name="Rahmani", email="sami@company.com", role="HR", team=t2, leave_balance=30, recovery_balance=15)
+    mf = Employee(first_name="Nadia", last_name="Benali", email="nadia@company.com", role="MANAGER_FUNCTIONAL", team=t1, leave_balance=25, recovery_balance=10)
+    mh = Employee(first_name="Karim", last_name="Haddad", email="karim@company.com", role="MANAGER_HIERARCHICAL", team=t1, leave_balance=25, recovery_balance=10)
+    emp = Employee(
+        first_name="Yassine",
+        last_name="Mansouri",
+        email="yassine@company.com",
+        role="EMPLOYEE",
+        team=t1,
+        leave_balance=20,
+        recovery_balance=8,
+        functional_manager_id=2,
+        hierarchical_manager_id=3,
+    )
+    db.session.add_all([hr, mf, mh, emp])
+    db.session.commit()
+
+
+def reserve_balance(employee: Employee, request_type: str, qty: float):
+    if request_type == "AUTH":
+        return True, ""
+    if request_type == "LEAVE":
+        available = employee.leave_balance - employee.leave_reserved
+        if available < qty:
+            return False, f"Solde congé insuffisant ({available:.1f} disponible)."
+        employee.leave_reserved += qty
+    elif request_type == "RECOVERY":
+        available = employee.recovery_balance - employee.recovery_reserved
+        if available < qty:
+            return False, f"Solde récupération insuffisant ({available:.1f} disponible)."
+        employee.recovery_reserved += qty
+    return True, ""
+
+
+def release_or_consume(request_obj: LeaveRequest, action: str):
+    employee = request_obj.employee
+    qty = request_obj.quantity
+    if request_obj.request_type == "AUTH":
+        return
+    if request_obj.request_type == "LEAVE":
+        if action == "release":
+            employee.leave_reserved = max(0, employee.leave_reserved - qty)
+        else:
+            employee.leave_reserved = max(0, employee.leave_reserved - qty)
+            employee.leave_balance = max(0, employee.leave_balance - qty)
+    if request_obj.request_type == "RECOVERY":
+        if action == "release":
+            employee.recovery_reserved = max(0, employee.recovery_reserved - qty)
+        else:
+            employee.recovery_reserved = max(0, employee.recovery_reserved - qty)
+            employee.recovery_balance = max(0, employee.recovery_balance - qty)
+
+
+@app.route("/")
 def index():
-    q = request.args.get("q", "").strip()
-    page = request.args.get("page", 1, type=int)
-    query = Student.query
-    if q:
-        like = f"%{q}%"
-        query = query.filter(
-            db.or_(
-                Student.first_name.ilike(like),
-                Student.last_name.ilike(like),
-                Student.email.ilike(like),
-                Student.phone.ilike(like),
-            )
-        )
-    students = query.order_by(Student.created_at.desc()).paginate(page=page, per_page=10)
-    return render_template("index.html", students=students, q=q)
+    return render_template("dashboard.html", employees=Employee.query.all(), requests=LeaveRequest.query.order_by(LeaveRequest.created_at.desc()).all())
 
-@app.route("/students/new", methods=["GET", "POST"])
-def create_student():
-    form = StudentForm()
+
+@app.route("/employees/new", methods=["GET", "POST"])
+def create_employee():
+    form = EmployeeForm()
+    teams = Team.query.order_by(Team.name).all()
+    employees = Employee.query.order_by(Employee.first_name).all()
+    form.team_id.choices = [(0, "--")]+[(t.id, t.name) for t in teams]
+    form.functional_manager_id.choices = [(0, "--")]+[(e.id, e.full_name) for e in employees]
+    form.hierarchical_manager_id.choices = [(0, "--")]+[(e.id, e.full_name) for e in employees]
+
     if form.validate_on_submit():
-        s = Student(
+        e = Employee(
             first_name=form.first_name.data,
             last_name=form.last_name.data,
             email=form.email.data,
-            phone=form.phone.data or None,
-            speciality=form.speciality.data or None,
-            student_class=form.student_class.data or None,
-            birthdate=form.birthdate.data or None,
+            role=form.role.data,
+            team_id=form.team_id.data or None,
+            functional_manager_id=form.functional_manager_id.data or None,
+            hierarchical_manager_id=form.hierarchical_manager_id.data or None,
+            leave_balance=form.leave_balance.data,
+            recovery_balance=form.recovery_balance.data,
         )
-        db.session.add(s)
-        try:
-            db.session.commit()
-            flash("Student created successfully.", "success")
-            return redirect(url_for("index"))
-        except Exception:
-            db.session.rollback()
-            flash("Email must be unique or data invalid.", "danger")
-    return render_template("form.html", form=form, title="Add student")
+        db.session.add(e)
+        db.session.commit()
+        flash("Employé créé.", "success")
+        return redirect(url_for("index"))
+    return render_template("employee_form.html", form=form)
 
-@app.route("/students/<int:student_id>", methods=["GET"])
-def show_student(student_id):
-    s = Student.query.get_or_404(student_id)
-    return render_template("show.html", s=s)
 
-@app.route("/students/<int:student_id>/edit", methods=["GET", "POST"])
-def edit_student(student_id):
-    s = Student.query.get_or_404(student_id)
-    form = StudentForm(obj=s)
+@app.route("/requests/new", methods=["GET", "POST"])
+def create_request():
+    form = LeaveRequestForm()
+    employees = Employee.query.order_by(Employee.first_name).all()
+    form.employee_id.choices = [(e.id, e.full_name) for e in employees]
+
     if form.validate_on_submit():
-        s.first_name = form.first_name.data
-        s.last_name = form.last_name.data
-        s.email = form.email.data
-        s.phone = form.phone.data or None
-        s.speciality = form.speciality.data or None
-        s.student_class = form.student_class.data or None
-        s.birthdate = form.birthdate.data or None
-        try:
-            db.session.commit()
-            flash("Student updated.", "success")
-            return redirect(url_for("show_student", student_id=s.id))
-        except Exception:
-            db.session.rollback()
-            flash("Update failed (email must be unique?).", "danger")
-    return render_template("form.html", form=form, title="Edit student")
+        employee = Employee.query.get_or_404(form.employee_id.data)
+        ok, message = reserve_balance(employee, form.request_type.data, form.quantity.data)
+        if not ok:
+            flash(message, "danger")
+            return render_template("request_form.html", form=form)
 
-@app.route("/students/<int:student_id>/delete", methods=["POST"])
-def delete_student(student_id):
-    s = Student.query.get_or_404(student_id)
-    db.session.delete(s)
+        request_obj = LeaveRequest(
+            employee_id=employee.id,
+            request_type=form.request_type.data,
+            start_date=form.start_date.data,
+            end_date=form.end_date.data,
+            quantity=form.quantity.data,
+            reason=form.reason.data,
+            status="PENDING_FUNCTIONAL",
+        )
+        db.session.add(request_obj)
+        db.session.commit()
+        flash("Demande soumise, solde réservé.", "success")
+        return redirect(url_for("index"))
+    return render_template("request_form.html", form=form)
+
+
+@app.route("/requests/<int:request_id>/<string:stage>/<string:decision>", methods=["POST"])
+def review_request(request_id: int, stage: str, decision: str):
+    request_obj = LeaveRequest.query.get_or_404(request_id)
+    if request_obj.status in {"REJECTED", "APPROVED"}:
+        flash("Cette demande est déjà finalisée.", "warning")
+        return redirect(url_for("index"))
+
+    if decision not in {"approve", "reject"}:
+        flash("Action invalide.", "danger")
+        return redirect(url_for("index"))
+
+    if stage == "functional" and request_obj.status == "PENDING_FUNCTIONAL":
+        request_obj.functional_decision = "APPROVED" if decision == "approve" else "REJECTED"
+        if decision == "approve":
+            request_obj.status = "PENDING_HIERARCHICAL"
+        else:
+            request_obj.status = "REJECTED"
+            release_or_consume(request_obj, "release")
+    elif stage == "hierarchical" and request_obj.status == "PENDING_HIERARCHICAL":
+        request_obj.hierarchical_decision = "APPROVED" if decision == "approve" else "REJECTED"
+        if decision == "approve":
+            release_or_consume(request_obj, "consume")
+            request_obj.status = "PENDING_HR"
+        else:
+            request_obj.status = "REJECTED"
+            release_or_consume(request_obj, "release")
+    elif stage == "hr" and request_obj.status == "PENDING_HR":
+        request_obj.hr_decision = "APPROVED" if decision == "approve" else "REJECTED"
+        request_obj.status = "APPROVED" if decision == "approve" else "REJECTED"
+        if decision == "reject":
+            flash("RH a rejeté après consommation: prévoir régularisation manuelle si nécessaire.", "warning")
+    else:
+        flash("Étape non valide pour cette demande.", "danger")
+        return redirect(url_for("index"))
+
     db.session.commit()
-    flash("Student deleted.", "info")
+    flash("Demande mise à jour.", "success")
     return redirect(url_for("index"))
+
 
 @app.route("/__health")
 def health():
-    return {"status": "ok", "students": Student.query.count()}
+    return {"status": "ok", "employees": Employee.query.count(), "requests": LeaveRequest.query.count()}
+
 
 with app.app_context():
     db.create_all()
+    _seed_if_empty()
 
-    # Simple schema upgrade for existing databases without new columns
-    inspector = inspect(db.engine)
-    columns = [col["name"] for col in inspector.get_columns("student")]
-    with db.engine.begin() as conn:
-        if "speciality" not in columns:
-            conn.execute(text("ALTER TABLE student ADD COLUMN speciality VARCHAR(80)"))
-        if "student_class" not in columns:
-            conn.execute(text("ALTER TABLE student ADD COLUMN student_class VARCHAR(30)"))
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/docs/leave_management_data_model.sql
+++ b/docs/leave_management_data_model.sql
@@ -1,0 +1,187 @@
+-- PostgreSQL schema for leave/recovery management
+
+CREATE TYPE employee_status AS ENUM ('active', 'inactive');
+CREATE TYPE role_code AS ENUM ('EMPLOYEE', 'MANAGER_FUNCTIONAL', 'MANAGER_HIERARCHICAL', 'HR');
+CREATE TYPE balance_bucket AS ENUM ('LEAVE', 'RECOVERY');
+CREATE TYPE request_unit AS ENUM ('DAY', 'HOUR');
+CREATE TYPE request_status AS ENUM (
+  'DRAFT',
+  'SUBMITTED',
+  'PENDING_FUNCTIONAL',
+  'PENDING_HIERARCHICAL',
+  'PENDING_HR',
+  'APPROVED',
+  'REJECTED',
+  'CANCELLED'
+);
+CREATE TYPE approval_decision AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+CREATE TYPE notification_channel AS ENUM ('IN_APP', 'EMAIL');
+CREATE TYPE transaction_type AS ENUM (
+  'ALLOCATION',
+  'MANUAL_ADJUSTMENT_PLUS',
+  'MANUAL_ADJUSTMENT_MINUS',
+  'RESERVE',
+  'RELEASE_RESERVE',
+  'CONSUME',
+  'REVERT_CONSUME'
+);
+CREATE TYPE transaction_direction AS ENUM ('CREDIT', 'DEBIT');
+
+CREATE TABLE teams (
+  id BIGSERIAL PRIMARY KEY,
+  name VARCHAR(120) NOT NULL UNIQUE,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE employees (
+  id BIGSERIAL PRIMARY KEY,
+  employee_code VARCHAR(32) NOT NULL UNIQUE,
+  first_name VARCHAR(120) NOT NULL,
+  last_name VARCHAR(120) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  phone VARCHAR(40),
+  job_title VARCHAR(120),
+  hire_date DATE NOT NULL,
+  status employee_status NOT NULL DEFAULT 'active',
+  team_id BIGINT REFERENCES teams(id),
+  functional_manager_id BIGINT REFERENCES employees(id),
+  hierarchical_manager_id BIGINT REFERENCES employees(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_not_self_functional_manager CHECK (functional_manager_id IS NULL OR functional_manager_id <> id),
+  CONSTRAINT chk_not_self_hierarchical_manager CHECK (hierarchical_manager_id IS NULL OR hierarchical_manager_id <> id)
+);
+
+CREATE TABLE roles (
+  id BIGSERIAL PRIMARY KEY,
+  code role_code NOT NULL UNIQUE,
+  label VARCHAR(120) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE employee_roles (
+  id BIGSERIAL PRIMARY KEY,
+  employee_id BIGINT NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+  role_id BIGINT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (employee_id, role_id)
+);
+
+CREATE TABLE leave_types (
+  id BIGSERIAL PRIMARY KEY,
+  code VARCHAR(40) NOT NULL UNIQUE,
+  label VARCHAR(120) NOT NULL,
+  balance_bucket balance_bucket,
+  unit request_unit NOT NULL DEFAULT 'DAY',
+  requires_attachment BOOLEAN NOT NULL DEFAULT FALSE,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE employee_balances (
+  id BIGSERIAL PRIMARY KEY,
+  employee_id BIGINT NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+  bucket balance_bucket NOT NULL,
+  acquired_amount NUMERIC(10,2) NOT NULL DEFAULT 0,
+  used_amount NUMERIC(10,2) NOT NULL DEFAULT 0,
+  reserved_amount NUMERIC(10,2) NOT NULL DEFAULT 0,
+  available_amount NUMERIC(10,2) NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (employee_id, bucket),
+  CONSTRAINT chk_non_negative_balance_values CHECK (
+    acquired_amount >= 0 AND used_amount >= 0 AND reserved_amount >= 0 AND available_amount >= 0
+  )
+);
+
+CREATE TABLE leave_requests (
+  id BIGSERIAL PRIMARY KEY,
+  request_number VARCHAR(40) NOT NULL UNIQUE,
+  employee_id BIGINT NOT NULL REFERENCES employees(id),
+  leave_type_id BIGINT NOT NULL REFERENCES leave_types(id),
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  requested_quantity NUMERIC(10,2) NOT NULL,
+  reason TEXT,
+  status request_status NOT NULL DEFAULT 'DRAFT',
+  current_approver_id BIGINT REFERENCES employees(id),
+  submitted_at TIMESTAMPTZ,
+  finalized_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_request_dates CHECK (start_date <= end_date),
+  CONSTRAINT chk_requested_quantity_positive CHECK (requested_quantity > 0)
+);
+
+CREATE TABLE request_approvals (
+  id BIGSERIAL PRIMARY KEY,
+  leave_request_id BIGINT NOT NULL REFERENCES leave_requests(id) ON DELETE CASCADE,
+  step_order SMALLINT NOT NULL,
+  step_role role_code NOT NULL,
+  approver_id BIGINT NOT NULL REFERENCES employees(id),
+  decision approval_decision NOT NULL DEFAULT 'PENDING',
+  comment TEXT,
+  decided_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (leave_request_id, step_order),
+  CONSTRAINT chk_step_order_range CHECK (step_order BETWEEN 1 AND 3),
+  CONSTRAINT chk_reject_comment CHECK (decision <> 'REJECTED' OR comment IS NOT NULL)
+);
+
+CREATE TABLE balance_transactions (
+  id BIGSERIAL PRIMARY KEY,
+  employee_id BIGINT NOT NULL REFERENCES employees(id),
+  bucket balance_bucket NOT NULL,
+  request_id BIGINT REFERENCES leave_requests(id),
+  transaction_type transaction_type NOT NULL,
+  amount NUMERIC(10,2) NOT NULL,
+  direction transaction_direction NOT NULL,
+  effective_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  note TEXT,
+  performed_by BIGINT REFERENCES employees(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_transaction_amount_positive CHECK (amount > 0)
+);
+
+CREATE TABLE request_attachments (
+  id BIGSERIAL PRIMARY KEY,
+  leave_request_id BIGINT NOT NULL REFERENCES leave_requests(id) ON DELETE CASCADE,
+  file_name VARCHAR(255) NOT NULL,
+  file_path TEXT NOT NULL,
+  mime_type VARCHAR(120),
+  uploaded_by BIGINT REFERENCES employees(id),
+  uploaded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE notifications (
+  id BIGSERIAL PRIMARY KEY,
+  employee_id BIGINT NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+  channel notification_channel NOT NULL,
+  title VARCHAR(180) NOT NULL,
+  message TEXT NOT NULL,
+  is_read BOOLEAN NOT NULL DEFAULT FALSE,
+  sent_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE audit_logs (
+  id BIGSERIAL PRIMARY KEY,
+  actor_id BIGINT REFERENCES employees(id),
+  entity_type VARCHAR(50) NOT NULL,
+  entity_id BIGINT NOT NULL,
+  action VARCHAR(80) NOT NULL,
+  old_value JSONB,
+  new_value JSONB,
+  ip_address VARCHAR(45),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_employees_team_id ON employees(team_id);
+CREATE INDEX idx_leave_requests_employee_status ON leave_requests(employee_id, status);
+CREATE INDEX idx_leave_requests_approver_status ON leave_requests(current_approver_id, status);
+CREATE INDEX idx_leave_requests_dates ON leave_requests(start_date, end_date);
+CREATE INDEX idx_request_approvals_req_step ON request_approvals(leave_request_id, step_order);
+CREATE INDEX idx_balance_transactions_emp_bucket_date ON balance_transactions(employee_id, bucket, effective_date);

--- a/docs/leave_management_erd.mmd
+++ b/docs/leave_management_erd.mmd
@@ -1,0 +1,106 @@
+erDiagram
+    teams ||--o{ employees : has
+    employees ||--o{ employees : functional_manager_of
+    employees ||--o{ employees : hierarchical_manager_of
+    employees ||--o{ employee_roles : assigned
+    roles ||--o{ employee_roles : grants
+    employees ||--o{ employee_balances : owns
+    employees ||--o{ leave_requests : creates
+    leave_types ||--o{ leave_requests : categorizes
+    leave_requests ||--o{ request_approvals : workflow
+    employees ||--o{ request_approvals : decides
+    leave_requests ||--o{ balance_transactions : impacts
+    employees ||--o{ balance_transactions : owns
+    leave_requests ||--o{ request_attachments : contains
+    employees ||--o{ notifications : receives
+    employees ||--o{ audit_logs : acts
+
+    teams {
+      bigint id PK
+      varchar name UK
+      text description
+    }
+    employees {
+      bigint id PK
+      varchar employee_code UK
+      varchar first_name
+      varchar last_name
+      varchar email UK
+      bigint team_id FK
+      bigint functional_manager_id FK
+      bigint hierarchical_manager_id FK
+    }
+    roles {
+      bigint id PK
+      role_code code UK
+      varchar label
+    }
+    employee_roles {
+      bigint id PK
+      bigint employee_id FK
+      bigint role_id FK
+    }
+    leave_types {
+      bigint id PK
+      varchar code UK
+      varchar label
+      balance_bucket balance_bucket
+      request_unit unit
+    }
+    employee_balances {
+      bigint id PK
+      bigint employee_id FK
+      balance_bucket bucket
+      numeric acquired_amount
+      numeric used_amount
+      numeric reserved_amount
+      numeric available_amount
+    }
+    leave_requests {
+      bigint id PK
+      varchar request_number UK
+      bigint employee_id FK
+      bigint leave_type_id FK
+      date start_date
+      date end_date
+      numeric requested_quantity
+      request_status status
+      bigint current_approver_id FK
+    }
+    request_approvals {
+      bigint id PK
+      bigint leave_request_id FK
+      smallint step_order
+      role_code step_role
+      bigint approver_id FK
+      approval_decision decision
+    }
+    balance_transactions {
+      bigint id PK
+      bigint employee_id FK
+      balance_bucket bucket
+      bigint request_id FK
+      transaction_type transaction_type
+      numeric amount
+      transaction_direction direction
+    }
+    request_attachments {
+      bigint id PK
+      bigint leave_request_id FK
+      varchar file_name
+      text file_path
+    }
+    notifications {
+      bigint id PK
+      bigint employee_id FK
+      notification_channel channel
+      varchar title
+      text message
+    }
+    audit_logs {
+      bigint id PK
+      bigint actor_id FK
+      varchar entity_type
+      bigint entity_id
+      varchar action
+    }

--- a/docs/leave_management_seed.sql
+++ b/docs/leave_management_seed.sql
@@ -1,0 +1,112 @@
+-- Minimal seed data for leave/recovery management demo
+
+INSERT INTO teams (name, description) VALUES
+('RH', 'Ressources Humaines'),
+('IT', 'Equipe informatique'),
+('Finance', 'Equipe finance');
+
+INSERT INTO roles (code, label) VALUES
+('EMPLOYEE', 'Employe'),
+('MANAGER_FUNCTIONAL', 'Manager fonctionnel'),
+('MANAGER_HIERARCHICAL', 'Manager hierarchique'),
+('HR', 'Ressources Humaines');
+
+INSERT INTO employees (employee_code, first_name, last_name, email, job_title, hire_date, team_id)
+VALUES
+('E1001', 'Sami', 'Rahmani', 'sami.rahmani@company.com', 'HR Officer', '2022-01-10', (SELECT id FROM teams WHERE name='RH')),
+('E1002', 'Nadia', 'Benali', 'nadia.benali@company.com', 'Delivery Manager', '2021-06-14', (SELECT id FROM teams WHERE name='IT')),
+('E1003', 'Karim', 'Haddad', 'karim.haddad@company.com', 'Engineering Manager', '2020-02-01', (SELECT id FROM teams WHERE name='IT')),
+('E1004', 'Yassine', 'Mansouri', 'yassine.mansouri@company.com', 'Software Engineer', '2024-03-11', (SELECT id FROM teams WHERE name='IT')),
+('E1005', 'Lina', 'Alaoui', 'lina.alaoui@company.com', 'Accountant', '2023-09-04', (SELECT id FROM teams WHERE name='Finance'));
+
+-- manager links
+UPDATE employees e
+SET functional_manager_id = (SELECT id FROM employees WHERE employee_code = 'E1002'),
+    hierarchical_manager_id = (SELECT id FROM employees WHERE employee_code = 'E1003')
+WHERE e.employee_code IN ('E1004', 'E1005');
+
+-- roles
+INSERT INTO employee_roles (employee_id, role_id)
+SELECT e.id, r.id
+FROM employees e
+JOIN roles r ON r.code = 'HR'
+WHERE e.employee_code = 'E1001';
+
+INSERT INTO employee_roles (employee_id, role_id)
+SELECT e.id, r.id
+FROM employees e
+JOIN roles r ON r.code = 'MANAGER_FUNCTIONAL'
+WHERE e.employee_code = 'E1002';
+
+INSERT INTO employee_roles (employee_id, role_id)
+SELECT e.id, r.id
+FROM employees e
+JOIN roles r ON r.code = 'MANAGER_HIERARCHICAL'
+WHERE e.employee_code = 'E1003';
+
+INSERT INTO employee_roles (employee_id, role_id)
+SELECT e.id, r.id
+FROM employees e
+JOIN roles r ON r.code = 'EMPLOYEE'
+WHERE e.employee_code IN ('E1004', 'E1005');
+
+-- leave types
+INSERT INTO leave_types (code, label, balance_bucket, unit, requires_attachment) VALUES
+('ANNUAL_LEAVE', 'Conge annuel', 'LEAVE', 'DAY', FALSE),
+('RECOVERY_DAY', 'Jour de recuperation', 'RECOVERY', 'DAY', FALSE),
+('AUTHORIZATION', 'Demande autorisation', NULL, 'HOUR', FALSE);
+
+-- balances for end users
+INSERT INTO employee_balances (employee_id, bucket, acquired_amount, used_amount, reserved_amount, available_amount)
+SELECT e.id, b.bucket, b.acquired, 0, 0, b.acquired
+FROM employees e
+CROSS JOIN (
+  VALUES
+    ('LEAVE'::balance_bucket, 24.00::numeric),
+    ('RECOVERY'::balance_bucket, 8.00::numeric)
+) AS b(bucket, acquired)
+WHERE e.employee_code IN ('E1004', 'E1005');
+
+-- sample request in progress for E1004
+INSERT INTO leave_requests (
+  request_number, employee_id, leave_type_id, start_date, end_date,
+  requested_quantity, reason, status, current_approver_id, submitted_at
+)
+VALUES (
+  'REQ-2026-0001',
+  (SELECT id FROM employees WHERE employee_code='E1004'),
+  (SELECT id FROM leave_types WHERE code='ANNUAL_LEAVE'),
+  '2026-06-08',
+  '2026-06-10',
+  3,
+  'Conge familial',
+  'PENDING_FUNCTIONAL',
+  (SELECT id FROM employees WHERE employee_code='E1002'),
+  NOW()
+);
+
+-- reserve balance for pending request
+INSERT INTO balance_transactions (employee_id, bucket, request_id, transaction_type, amount, direction, note, performed_by)
+VALUES (
+  (SELECT id FROM employees WHERE employee_code='E1004'),
+  'LEAVE',
+  (SELECT id FROM leave_requests WHERE request_number='REQ-2026-0001'),
+  'RESERVE',
+  3,
+  'DEBIT',
+  'Reservation automatique a la soumission',
+  (SELECT id FROM employees WHERE employee_code='E1004')
+);
+
+UPDATE employee_balances
+SET reserved_amount = reserved_amount + 3,
+    available_amount = available_amount - 3,
+    updated_at = NOW()
+WHERE employee_id = (SELECT id FROM employees WHERE employee_code='E1004')
+  AND bucket = 'LEAVE';
+
+INSERT INTO request_approvals (leave_request_id, step_order, step_role, approver_id, decision)
+VALUES
+((SELECT id FROM leave_requests WHERE request_number='REQ-2026-0001'), 1, 'MANAGER_FUNCTIONAL', (SELECT id FROM employees WHERE employee_code='E1002'), 'PENDING'),
+((SELECT id FROM leave_requests WHERE request_number='REQ-2026-0001'), 2, 'MANAGER_HIERARCHICAL', (SELECT id FROM employees WHERE employee_code='E1003'), 'PENDING'),
+((SELECT id FROM leave_requests WHERE request_number='REQ-2026-0001'), 3, 'HR', (SELECT id FROM employees WHERE employee_code='E1001'), 'PENDING');

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,28 +1,28 @@
-
 <!doctype html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Student Manager</title>
+    <title>Gestion des congés</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="{{ url_for('static', filename='custom.css') }}" rel="stylesheet">
   </head>
   <body class="bg-light">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container">
-        <a class="navbar-brand" href="{{ url_for('index') }}">Student Manager</a>
-        <a class="btn btn-success ms-auto" href="{{ url_for('create_student') }}">+ Add</a>
+        <a class="navbar-brand" href="{{ url_for('index') }}">Gestion Congés</a>
+        <div class="ms-auto d-flex gap-2">
+          <a class="btn btn-outline-light" href="{{ url_for('create_employee') }}">+ Employé</a>
+          <a class="btn btn-success" href="{{ url_for('create_request') }}">+ Demande</a>
+        </div>
       </div>
     </nav>
     <main class="container py-4">
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
-          <div class="mb-3">
-            {% for category, message in messages %}
-              <div class="alert alert-{{ category }} mb-2">{{ message }}</div>
-            {% endfor %}
-          </div>
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }}">{{ message }}</div>
+          {% endfor %}
         {% endif %}
       {% endwith %}
       {% block content %}{% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block content %}
+<h4 class="mb-3">Launchpad</h4>
+<div class="row g-3 mb-4">
+  {% for e in employees %}
+  <div class="col-md-4">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        <h6 class="mb-1">{{ e.full_name }} <span class="badge text-bg-secondary">{{ e.role }}</span></h6>
+        <div class="small text-muted">{{ e.email }}</div>
+        <div class="mt-2 small">Congé: {{ '%.1f'|format(e.leave_balance) }} (réservé {{ '%.1f'|format(e.leave_reserved) }})</div>
+        <div class="small">Récup: {{ '%.1f'|format(e.recovery_balance) }} (réservé {{ '%.1f'|format(e.recovery_reserved) }})</div>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h5>Demandes</h5>
+    <div class="table-responsive">
+      <table class="table table-hover">
+        <thead>
+          <tr><th>ID</th><th>Employé</th><th>Type</th><th>Période</th><th>Qté</th><th>Statut</th><th>Actions</th></tr>
+        </thead>
+        <tbody>
+          {% for r in requests %}
+          <tr>
+            <td>{{ r.id }}</td>
+            <td>{{ r.employee.full_name }}</td>
+            <td>{{ r.request_type }}</td>
+            <td>{{ r.start_date }} → {{ r.end_date }}</td>
+            <td>{{ r.quantity }}</td>
+            <td><span class="badge text-bg-info">{{ r.status }}</span></td>
+            <td class="d-flex gap-1 flex-wrap">
+              {% if r.status == 'PENDING_FUNCTIONAL' %}
+              <form method="post" action="{{ url_for('review_request', request_id=r.id, stage='functional', decision='approve') }}"><button class="btn btn-sm btn-success">MF ✅</button></form>
+              <form method="post" action="{{ url_for('review_request', request_id=r.id, stage='functional', decision='reject') }}"><button class="btn btn-sm btn-danger">MF ❌</button></form>
+              {% elif r.status == 'PENDING_HIERARCHICAL' %}
+              <form method="post" action="{{ url_for('review_request', request_id=r.id, stage='hierarchical', decision='approve') }}"><button class="btn btn-sm btn-success">MH ✅</button></form>
+              <form method="post" action="{{ url_for('review_request', request_id=r.id, stage='hierarchical', decision='reject') }}"><button class="btn btn-sm btn-danger">MH ❌</button></form>
+              {% elif r.status == 'PENDING_HR' %}
+              <form method="post" action="{{ url_for('review_request', request_id=r.id, stage='hr', decision='approve') }}"><button class="btn btn-sm btn-success">RH ✅</button></form>
+              <form method="post" action="{{ url_for('review_request', request_id=r.id, stage='hr', decision='reject') }}"><button class="btn btn-sm btn-danger">RH ❌</button></form>
+              {% endif %}
+            </td>
+          </tr>
+          {% else %}
+          <tr><td colspan="7" class="text-center text-muted">Aucune demande.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/employee_form.html
+++ b/templates/employee_form.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h5>Créer un employé</h5>
+    <form method="post">
+      {{ form.hidden_tag() }}
+      <div class="row g-3">
+        <div class="col-md-6">{{ form.first_name.label(class='form-label') }}{{ form.first_name(class='form-control') }}</div>
+        <div class="col-md-6">{{ form.last_name.label(class='form-label') }}{{ form.last_name(class='form-control') }}</div>
+        <div class="col-md-6">{{ form.email.label(class='form-label') }}{{ form.email(class='form-control') }}</div>
+        <div class="col-md-6">{{ form.role.label(class='form-label') }}{{ form.role(class='form-select') }}</div>
+        <div class="col-md-4">{{ form.team_id.label(class='form-label') }}{{ form.team_id(class='form-select') }}</div>
+        <div class="col-md-4">{{ form.functional_manager_id.label(class='form-label') }}{{ form.functional_manager_id(class='form-select') }}</div>
+        <div class="col-md-4">{{ form.hierarchical_manager_id.label(class='form-label') }}{{ form.hierarchical_manager_id(class='form-select') }}</div>
+        <div class="col-md-6">{{ form.leave_balance.label(class='form-label') }}{{ form.leave_balance(class='form-control') }}</div>
+        <div class="col-md-6">{{ form.recovery_balance.label(class='form-label') }}{{ form.recovery_balance(class='form-control') }}</div>
+      </div>
+      <div class="mt-3">{{ form.submit(class='btn btn-primary') }}</div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/request_form.html
+++ b/templates/request_form.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="card shadow-sm">
+  <div class="card-body">
+    <h5>Nouvelle demande (congé / récupération / autorisation)</h5>
+    <form method="post">
+      {{ form.hidden_tag() }}
+      <div class="row g-3">
+        <div class="col-md-6">{{ form.employee_id.label(class='form-label') }}{{ form.employee_id(class='form-select') }}</div>
+        <div class="col-md-6">{{ form.request_type.label(class='form-label') }}{{ form.request_type(class='form-select') }}</div>
+        <div class="col-md-4">{{ form.start_date.label(class='form-label') }}{{ form.start_date(class='form-control') }}</div>
+        <div class="col-md-4">{{ form.end_date.label(class='form-label') }}{{ form.end_date(class='form-control') }}</div>
+        <div class="col-md-4">{{ form.quantity.label(class='form-label') }}{{ form.quantity(class='form-control') }}</div>
+        <div class="col-12">{{ form.reason.label(class='form-label') }}{{ form.reason(class='form-control', rows='3') }}</div>
+      </div>
+      <div class="mt-3">{{ form.submit(class='btn btn-primary') }}</div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,11 +4,12 @@ import app
 
 
 def setup_module(module):
-    """Prepare a fresh database for tests."""
     app.app.config["WTF_CSRF_ENABLED"] = False
     with app.app.app_context():
         app.db.drop_all()
         app.db.create_all()
+        app._seed_if_empty()
+
 
 def test_health_endpoint():
     client = app.app.test_client()
@@ -16,54 +17,63 @@ def test_health_endpoint():
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["status"] == "ok"
+    assert data["employees"] >= 1
 
 
-def test_create_edit_student_fields():
+def test_create_leave_request_and_reserve_balance():
     client = app.app.test_client()
-    # create a student with new fields
+    with app.app.app_context():
+        employee = app.Employee.query.filter_by(email="yassine@company.com").first()
+        assert employee is not None
+        before_reserved = employee.leave_reserved
+
     resp = client.post(
-        "/students/new",
+        "/requests/new",
         data={
-            "first_name": "John",
-            "last_name": "Doe",
-            "email": "john@example.com",
-            "phone": "",
-            "birthdate": "",
-            "speciality": "Math",
-            "student_class": "1A",
+            "employee_id": employee.id,
+            "request_type": "LEAVE",
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-02",
+            "quantity": "2",
+            "reason": "Test congé",
         },
         follow_redirects=True,
     )
     assert resp.status_code == 200
 
     with app.app.app_context():
-        s = app.Student.query.filter_by(email="john@example.com").first()
-        assert s is not None
-        assert s.speciality == "Math"
-        assert s.student_class == "1A"
-        student_id = s.id
+        employee = app.Employee.query.get(employee.id)
+        assert employee.leave_reserved == before_reserved + 2
+        req = app.LeaveRequest.query.order_by(app.LeaveRequest.id.desc()).first()
+        assert req.status == "PENDING_FUNCTIONAL"
 
-    # edit the student
-    resp = client.post(
-        f"/students/{student_id}/edit",
-        data={
-            "first_name": "John",
-            "last_name": "Doe",
-            "email": "john@example.com",
-            "phone": "",
-            "birthdate": "",
-            "speciality": "Physics",
-            "student_class": "2B",
-        },
-        follow_redirects=True,
-    )
+
+def test_approval_flow_to_hr_stage_consumes_balance():
+    client = app.app.test_client()
+    with app.app.app_context():
+        employee = app.Employee.query.filter_by(email="yassine@company.com").first()
+        req = app.LeaveRequest(
+            employee_id=employee.id,
+            request_type="LEAVE",
+            start_date=app.date(2026, 7, 1),
+            end_date=app.date(2026, 7, 1),
+            quantity=1,
+            status="PENDING_FUNCTIONAL",
+        )
+        ok, _ = app.reserve_balance(employee, "LEAVE", 1)
+        assert ok
+        before_balance = employee.leave_balance
+        app.db.session.add(req)
+        app.db.session.commit()
+        req_id = req.id
+
+    resp = client.post(f"/requests/{req_id}/functional/approve", follow_redirects=True)
+    assert resp.status_code == 200
+    resp = client.post(f"/requests/{req_id}/hierarchical/approve", follow_redirects=True)
     assert resp.status_code == 200
 
     with app.app.app_context():
-        s = app.Student.query.get(student_id)
-        assert s.speciality == "Physics"
-        assert s.student_class == "2B"
-
-    resp = client.get(f"/students/{student_id}")
-    assert b"Physics" in resp.data
-    assert b"2B" in resp.data
+        req = app.LeaveRequest.query.get(req_id)
+        employee = app.Employee.query.get(req.employee_id)
+        assert req.status == "PENDING_HR"
+        assert employee.leave_balance == before_balance - 1


### PR DESCRIPTION
### Motivation
- Introduce a simple leave/recovery management domain to replace the previous student example and provide basic employee, team and leave request handling.
- Provide a minimal workflow for multi-stage approvals (functional, hierarchical, HR) with balance reservation and consumption logic.
- Ship a baseline PostgreSQL schema, ERD and seed data to support future migration and demos.

### Description
- Replace the `Student` model with new domain models `Team`, `Employee`, and `LeaveRequest`, add constraints and convenience properties like `Employee.full_name` and validations on `LeaveRequest`.
- Add forms `EmployeeForm` and `LeaveRequestForm`, helper functions `reserve_balance`, `release_or_consume`, and a seeder `_seed_if_empty`, and expose routes `create_employee`, `create_request`, and `review_request` to handle CRUD and approval actions.
- Update app configuration to read `DATABASE_URL` with a default `sqlite:///leave_app.db`, modify the health endpoint to report employee/request counts, and enable seeding and DB creation on startup.
- Add new templates `dashboard.html`, `employee_form.html`, `request_form.html` and update `base.html` to French labels and new navigation, plus new docs: `docs/leave_management_data_model.sql`, `docs/leave_management_erd.mmd`, and `docs/leave_management_seed.sql`.

### Testing
- Ran unit tests in `tests/test_app.py` which include `test_health_endpoint`, `test_create_leave_request_and_reserve_balance`, and `test_approval_flow_to_hr_stage_consumes_balance` to exercise seeding, request submission and multi-stage approval balance consumption.
- Tests were executed against a fresh test DB created in `setup_module` (which now calls `_seed_if_empty`) and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad2a49adc832ba18d4f1a2536a580)